### PR TITLE
Fixed bug with charts hiding in stack mode

### DIFF
--- a/src/plugins/jquery.flot.stack.js
+++ b/src/plugins/jquery.flot.stack.js
@@ -48,7 +48,7 @@ charts or filled areas).
                     break;
                 }
 
-                if (allseries[i].stack === s.stack) {
+                if (allseries[i].stack === s.stack && allseries[i].data.length) {
                     res = allseries[i];
                 }
             }


### PR DESCRIPTION
When the dataKey(from the stacked group) is hidden via chart-legend, its "data-points" array becomes empty. The "flot-stack"-plugin hid all next non-empty series(that comes after empty data-series).
The current fix solves this issue by skipping all empty series of "stacked"-group from plugin processing.